### PR TITLE
fix a UAF bug in Mac impl appended to rust-openssl

### DIFF
--- a/openssl/src/mac.rs
+++ b/openssl/src/mac.rs
@@ -33,7 +33,7 @@ impl Mac {
             let ptr = cvt_p(ffi::EVP_MAC_fetch(
                 ctx.map_or(ptr::null_mut(), ForeignTypeRef::as_ptr),
                 algorithm.as_ptr(),
-                properties.map_or(ptr::null_mut(), |s| s.as_ptr()),
+                properties.as_ref().map_or(ptr::null_mut(), |s| s.as_ptr()),
             ))?;
 
             Ok(Mac::from_ptr(ptr))


### PR DESCRIPTION
After merging the upstream rust-openssl, pls merge this as well to fix the UAF.